### PR TITLE
Make apparmor-config work with trusty

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-apparmor-config (1.2.7) unstable; urgency=low
+
+  * Reflect apparmor configuration changes in Ubuntu 14.04
+
+ -- Victor Vasiliev <vasilvv@mit.edu>  Thu, 27 Mar 2014 01:32:04 -0400
+
 debathena-apparmor-config (1.2.6) unstable; urgency=low
 
   * Depend explicitly on CUPS

--- a/debian/transform_X.debathena
+++ b/debian/transform_X.debathena
@@ -1,2 +1,2 @@
 #!/usr/bin/perl -p0
-s|^(\s*)\@\{HOME\}/.Xauthority\s+r,$|$&\n$1/var/run/athena-sessions/xauth-* r,|m or die;
+s|^(\s*)(owner )?\@\{HOME\}/.Xauthority\s+r,$|$&\n$1/var/run/athena-sessions/xauth-* r,|m or die;


### PR DESCRIPTION
This reflects added "owner" modifier in /etc/apparmor.d/abstractions/X
