### PR TITLE
Transform the xdg-desktop abstraction for dconf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+debathena-apparmor-config (1.2.8) unstable; urgency=low
+
+  * Transform the xdg-desktop profile to take into account the fact that
+    the XDG cache may now be in /var/run, and also to explicitly allow
+    dconf profiles (Trac: #1505)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Sun, 06 Jul 2014 18:49:08 -0400
+
 debathena-apparmor-config (1.2.7) unstable; urgency=low
 
   * Reflect apparmor configuration changes in Ubuntu 14.04

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,12 @@ else
     DEB_UNDIVERT_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/X.debathena
 endif
 
+ifneq ($(wildcard /etc/apparmor.d/abstractions/xdg-desktop),)
+    DEB_TRANSFORM_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/xdg-desktop.debathena
+else
+    DEB_UNDIVERT_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/xdg-desktop.debathena
+endif
+
 ifneq ($(wildcard /etc/apparmor.d/abstractions/nameservice),)
     DEB_TRANSFORM_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/nameservice.debathena
 else

--- a/debian/transform_xdg-desktop.debathena
+++ b/debian/transform_xdg-desktop.debathena
@@ -1,0 +1,3 @@
+#!/usr/bin/perl -p0
+s|^(\s*)owner \@\{HOME\}/.cache/\s+rw,$|$&\n$1owner /{,var/}run/athena-sessions/xdgcache-*/** rw,|m or die;
+s|$|\n\n  # Allow access to dconf profiles and databases\n  /etc/dconf/** r,\n| or die;


### PR DESCRIPTION
Upstream is dumb, and nothing takes into account the fact
that you might want to use a DCONF_PROFILE other than "user",
and thus would need access to read said profile out of
/etc/dconf.  So we transform xdg-desktop to allow read access
to everything below /etc/dconf, and while we're at it, make it
aware of the fact that XDG_CACHE_HOME can, like, point to other
directories.  (Trac: #1505)
