### PR TITLE
Make apparmor suck less with dconf and OpenAFS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+debathena-apparmor-config (1.2.9) unstable; urgency=low
+
+  * Further transform the xdg-desktop profile to allow access to dconf
+    profiles in /run/user or ~/.cache.  Upstream only allows access to the
+    "user" profile. (Trac: #1505)
+  * Transform the 'base' abstraction to allow read access to the OpenAFS
+    cache, otherwise Evince will attempt to frob things in ~/.local/share,
+    fail, and then OpenAFS will think the volume vanished. (Trac: #1505)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Mon, 07 Jul 2014 14:36:48 -0400
+
 debathena-apparmor-config (1.2.8) unstable; urgency=low
 
   * Transform the xdg-desktop profile to take into account the fact that

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,12 @@ else
     DEB_UNDIVERT_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/kerberosclient.debathena
 endif
 
+ifneq ($(wildcard /etc/apparmor.d/abstractions/base),)
+    DEB_TRANSFORM_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/base.debathena
+else
+    DEB_UNDIVERT_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/base.debathena
+endif
+
 ifneq ($(wildcard /etc/apparmor.d/abstractions/cups-client),)
     DEB_TRANSFORM_FILES_debathena-apparmor-config += /etc/apparmor.d/abstractions/cups-client.debathena
 else

--- a/debian/transform_base.debathena
+++ b/debian/transform_base.debathena
@@ -1,0 +1,7 @@
+#!/bin/sh
+cat
+echo
+cat <<EOF
+  # Allow anything to read from the openafs cache
+  /var/cache/openafs/** r,
+EOF

--- a/debian/transform_xdg-desktop.debathena
+++ b/debian/transform_xdg-desktop.debathena
@@ -1,3 +1,15 @@
 #!/usr/bin/perl -p0
 s|^(\s*)owner \@\{HOME\}/.cache/\s+rw,$|$&\n$1owner /{,var/}run/athena-sessions/xdgcache-*/** rw,|m or die;
-s|$|\n\n  # Allow access to dconf profiles and databases\n  /etc/dconf/** r,\n| or die;
+END {
+    print <<'EOF'
+
+  # Allow access to dconf profiles and databases
+  /etc/dconf/** r,
+
+  # And runtime dconf profiles (in HOME or /run/user)
+  owner @{HOME}/.{cache,config}/dconf/     w,
+  owner @{HOME}/.{cache,config}/dconf/**   rw,
+  owner /{,var/}run/user/*/dconf/          w,
+  owner /{,var/}run/user/*/dconf/**        rw,
+EOF
+}


### PR DESCRIPTION
- Allow unconditional read access to the OpenAFS cache, otherwise
  hilarity ensues with OpenAFS thinking the server went away.
- Allow read/write access to ANY dconf profile, not just the upstream one
  named "user"
