### PR TITLE
Also allow write access to the OpenAFS cache

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+debathena-apparmor-config (1.2.10) unstable; urgency=medium
+
+  * Also allow write access to the OpenAFS cache, for the same reason that
+    read access was allowed in 1.2.9.
+
+ -- Anders Kaseorg <andersk@mit.edu>  Tue, 06 Feb 2018 19:08:38 -0500
+
 debathena-apparmor-config (1.2.9.1) unstable; urgency=low
 
   * And fix an upstream bug (LP: #1339727) which configures the wrong

--- a/debian/transform_base.debathena
+++ b/debian/transform_base.debathena
@@ -2,6 +2,7 @@
 cat
 echo
 cat <<EOF
-  # Allow anything to read from the openafs cache
-  /var/cache/openafs/** r,
+  # OpenAFS seems to use the credentials of random processes to read
+  # and write the AFS cache, so we need to allow all such accesses.
+  /var/cache/openafs/** rw,
 EOF


### PR DESCRIPTION
`[ 1381.692649] type=1400 audit(1517950607.854:76): apparmor="DENIED" operation="file_perm" profile="/usr/bin/evince" name="/var/cache/openafs/D35/V71954" pid=4951 comm="evince" requested_mask="w" denied_mask="w" fsuid=111264 ouid=0`

This continues to be a bad workaround for an OpenAFS bug, but it’s all we can do right now.